### PR TITLE
feat: add addressCountry to both credential types

### DIFF
--- a/credentials/draft/DSCSAATPCredential-v2.0.0.jsonld
+++ b/credentials/draft/DSCSAATPCredential-v2.0.0.jsonld
@@ -20,11 +20,12 @@
         "organizationType": {"@id": "schema:additionalType", "@type": "schema:additionalType"},
         "legalName": "schema:legalName",
         "parentOrganization": "schema:parentOrganization",
+        "globalLocationNumber": "schema:globalLocationNumber",
         "streetAddress": "schema:streetAddress",
         "addressLocality": "schema:addressLocality",
         "addressRegion": "schema:addressRegion",
         "postalCode": "schema:postalCode",
-        "globalLocationNumber": "schema:globalLocationNumber"
+        "addressCountry": "schema:addressCountry"
       }
     }
   }

--- a/credentials/draft/IdentityCredential-v2.0.0.jsonld
+++ b/credentials/draft/IdentityCredential-v2.0.0.jsonld
@@ -22,7 +22,8 @@
         "streetAddress": "schema:streetAddress",
         "addressLocality": "schema:addressLocality",
         "addressRegion": "schema:addressRegion",
-        "postalCode": "schema:postalCode"
+        "postalCode": "schema:postalCode",
+        "addressCountry": "schema:addressCountry"
       }
     }
   }


### PR DESCRIPTION
Propsoal: Add missing field `addressCountry` to both credential types, as not every company might have it's headquarters based in the US.