### PR TITLE
schema:additionalType is a property - not a value type

### DIFF
--- a/credentials/draft/DSCSAATPCredential-v2.0.0.jsonld
+++ b/credentials/draft/DSCSAATPCredential-v2.0.0.jsonld
@@ -12,10 +12,7 @@
         "id": "@id",
         "type": "@type",
         "schema": "http://schema.org/",
-        "organizationType": {
-          "@id": "schema:additionalType",
-          "@type": "schema:additionalType"
-        },
+        "organizationType": "schema:additionalType",
         "identifier": {
           "@id": "https://schema.org/identifier",
           "@type": "schema:identifier",


### PR DESCRIPTION
I noticed this while helping Elizabeth Waldorf (Tracelink) with some SHACL validation issues.  One of the glitches I noticed was that "organizationType" was not only being mapped to schema:additionalType (via "@id" : "schema:additionalType" ) - that's OK; what is not OK is casting a string value such as "Wholesaler" to "Wholesaler"^^schema:additionalType when schema:additionalType is not even a data type in the way that xsd:date is.